### PR TITLE
Add placeholders for new subpackages

### DIFF
--- a/lambda_lib/__init__.py
+++ b/lambda_lib/__init__.py
@@ -5,3 +5,5 @@
 #@  doc: Root package for λ library skeleton.
 #@end
 
+from . import patterns, sensors, memory, metrics, governance
+

--- a/lambda_lib/governance/__init__.py
+++ b/lambda_lib/governance/__init__.py
@@ -1,0 +1,6 @@
+#@module:
+#@  version: "0.3"
+#@  layer: governance
+#@  doc: Governance policy layer.
+#@end
+

--- a/lambda_lib/memory/__init__.py
+++ b/lambda_lib/memory/__init__.py
@@ -1,0 +1,6 @@
+#@module:
+#@  version: "0.3"
+#@  layer: memory
+#@  doc: Memory management primitives.
+#@end
+

--- a/lambda_lib/metrics/__init__.py
+++ b/lambda_lib/metrics/__init__.py
@@ -1,0 +1,6 @@
+#@module:
+#@  version: "0.3"
+#@  layer: metrics
+#@  doc: Metrics collection utilities.
+#@end
+

--- a/lambda_lib/patterns/__init__.py
+++ b/lambda_lib/patterns/__init__.py
@@ -1,0 +1,6 @@
+#@module:
+#@  version: "0.3"
+#@  layer: patterns
+#@  doc: Pattern-matching utilities.
+#@end
+

--- a/lambda_lib/sensors/__init__.py
+++ b/lambda_lib/sensors/__init__.py
@@ -1,0 +1,6 @@
+#@module:
+#@  version: "0.3"
+#@  layer: sensors
+#@  doc: Sensor interface layer.
+#@end
+


### PR DESCRIPTION
## Summary
- add empty modules for `patterns`, `sensors`, `memory`, `metrics` and `governance`
- register those packages in `lambda_lib.__init__`

## Testing
- `python -m compileall -q lambda_lib`
- `python - <<'PY'
import lambda_lib
print('has patterns', hasattr(lambda_lib, 'patterns'))
print('has sensors', hasattr(lambda_lib, 'sensors'))
print('has memory', hasattr(lambda_lib, 'memory'))
print('has metrics', hasattr(lambda_lib, 'metrics'))
print('has governance', hasattr(lambda_lib, 'governance'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6869020248708329aa8924d694a6a64b