### PR TITLE
Implement evaluation loop in LambdaEngine with tests

### DIFF
--- a/lambda_lib/core/engine.py
+++ b/lambda_lib/core/engine.py
@@ -27,6 +27,17 @@ class LambdaEngine:
 
     def execute(self, graph: Graph) -> Executor:
         assert len(graph.nodes) > 0
+
+        # simple evaluation loop applying registered operations by name
+        graph.state = "running"
+        new_nodes = []
+        for node in graph.nodes:
+            operation = self.registry.get(node.label)
+            if operation is not None:
+                node = operation(node)
+            new_nodes.append(node)
+        graph.nodes = new_nodes
+
         executor = Executor(graph)
         executor.execute()
         assert executor.state == "ready"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pytest
+
+# Ensure the project root is on sys.path so lambda_lib can be imported when
+# running tests directly.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.engine import LambdaEngine
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.core.operation import LambdaOperation
+from lambda_lib.graph import Graph
+
+
+def test_engine_execute_returns_ready_executor():
+    node = LambdaNode("noop")
+    graph = Graph([node])
+
+    def noop_op(n: LambdaNode) -> LambdaNode:
+        return LambdaNode("noop", data=n.data, links=n.links)
+
+    op = LambdaOperation("noop", noop_op)
+
+    engine = LambdaEngine()
+    engine.register(op)
+
+    executor = engine.execute(graph)
+    assert executor.state == "ready"


### PR DESCRIPTION
## Summary
- implement a simple evaluation loop in `LambdaEngine.execute`
- add pytest-based unit test covering engine execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686902fa58088329951b21cd47ff6dba