### PR TITLE
Implement pattern matching and rewrite utilities

### DIFF
--- a/lambda_lib/core/__init__.py
+++ b/lambda_lib/core/__init__.py
@@ -1,7 +1,9 @@
 #@module:
 #@  version: "0.3"
 #@  layer: core
-#@  exposes: []
+#@  exposes: [Pattern, Rewrite]
 #@  doc: Core sub‑package.
 #@end
 
+from .pattern import Pattern, MatchResult
+from .rewrite import Rewrite

--- a/lambda_lib/core/pattern.py
+++ b/lambda_lib/core/pattern.py
@@ -1,0 +1,46 @@
+#@module:
+#@  version: "0.3"
+#@  layer: core
+#@  exposes: [Pattern, MatchResult]
+#@  doc: Simple pattern matching utilities for LambdaNode graphs.
+#@end
+
+from dataclasses import dataclass
+from typing import List
+
+from .node import LambdaNode
+
+
+@dataclass
+class MatchResult:
+    """Result of applying a :class:`Pattern` to a node."""
+
+    matches: List[LambdaNode]
+
+    def succeeded(self) -> bool:
+        """Return True if the pattern matched at least one node."""
+        return bool(self.matches)
+
+
+@dataclass
+class Pattern:
+    """Pattern that matches :class:`LambdaNode` instances by label."""
+
+    label: str
+
+    #@contract:
+    #@  pre: isinstance(node, LambdaNode)
+    #@  post:
+    #@    - isinstance(result, MatchResult)
+    #@    - result.matches is not None
+    #@  assigns: []
+    #@end
+    def match(self, node: LambdaNode) -> MatchResult:
+        """Return a MatchResult if this pattern applies to ``node``."""
+        assert isinstance(node, LambdaNode)
+        if node.label == self.label:
+            result = MatchResult([node])
+        else:
+            result = MatchResult([])
+        assert result.matches is not None
+        return result

--- a/lambda_lib/core/rewrite.py
+++ b/lambda_lib/core/rewrite.py
@@ -1,0 +1,36 @@
+#@module:
+#@  version: "0.3"
+#@  layer: core
+#@  exposes: [Rewrite]
+#@  doc: Representation of graph rewrite actions.
+#@end
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from .node import LambdaNode
+
+
+@dataclass
+class Rewrite:
+    """Collects actions that mutate a graph of :class:`LambdaNode`."""
+
+    actions: List[Tuple[str, LambdaNode]] = field(default_factory=list)
+
+    def add(self, node: LambdaNode) -> None:
+        """Record an add-node action."""
+        self.actions.append(("add", node))
+
+    def remove(self, node: LambdaNode) -> None:
+        """Record a remove-node action."""
+        self.actions.append(("remove", node))
+
+    #@contract:
+    #@  post: len(result) > 0
+    #@  assigns: []
+    #@end
+    def get_actions(self) -> List[Tuple[str, LambdaNode]]:
+        """Return the list of rewrite actions."""
+        result = list(self.actions)
+        assert len(result) > 0
+        return result


### PR DESCRIPTION
## Summary
- add `Pattern` and `MatchResult` for matching lambda nodes
- add `Rewrite` dataclass that records graph edits
- expose `Pattern` and `Rewrite` in `lambda_lib.core`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690b6dd52883299660205d13af4e39