### PR TITLE
Add pattern rewrite ops

### DIFF
--- a/lambda_lib/ops/__init__.py
+++ b/lambda_lib/ops/__init__.py
@@ -1,7 +1,12 @@
 #@module:
 #@  version: "0.3"
 #@  layer: ops
-#@  exposes: []
+#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule]
 #@  doc: Package for built‑in λ operations.
 #@end
 
+from .eval import eval_rule
+from .mirror import mirror_rule
+from .phase import phase_rule
+from .convolve import convolve_rule
+from .spawn import spawn_rule

--- a/lambda_lib/ops/convolve.py
+++ b/lambda_lib/ops/convolve.py
@@ -1,0 +1,14 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [convolve_rule]
+#@  doc: Pattern rewrite for convolving variants.
+#@end
+
+from ..patterns import parse_pattern
+
+#@contract:
+#@  post: convolve_rule.match is not None
+#@  assigns: []
+#@end
+convolve_rule = parse_pattern("x -> convolved(x)")

--- a/lambda_lib/ops/eval.py
+++ b/lambda_lib/ops/eval.py
@@ -1,0 +1,14 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [eval_rule]
+#@  doc: Pattern rewrite for evaluation.
+#@end
+
+from ..patterns import parse_pattern
+
+#@contract:
+#@  post: eval_rule.match is not None
+#@  assigns: []
+#@end
+eval_rule = parse_pattern("x -> eval(x)")

--- a/lambda_lib/ops/mirror.py
+++ b/lambda_lib/ops/mirror.py
@@ -1,0 +1,14 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [mirror_rule]
+#@  doc: Pattern rewrite for mirroring nodes.
+#@end
+
+from ..patterns import parse_pattern
+
+#@contract:
+#@  post: mirror_rule.match is not None
+#@  assigns: []
+#@end
+mirror_rule = parse_pattern("x -> x")

--- a/lambda_lib/ops/phase.py
+++ b/lambda_lib/ops/phase.py
@@ -1,0 +1,14 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [phase_rule]
+#@  doc: Pattern rewrite for phase shifting.
+#@end
+
+from ..patterns import parse_pattern
+
+#@contract:
+#@  post: phase_rule.match is not None
+#@  assigns: []
+#@end
+phase_rule = parse_pattern("x -> phased(x)")

--- a/lambda_lib/ops/spawn.py
+++ b/lambda_lib/ops/spawn.py
@@ -1,0 +1,14 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [spawn_rule]
+#@  doc: Pattern rewrite for spawning new nodes.
+#@end
+
+from ..patterns import parse_pattern
+
+#@contract:
+#@  post: spawn_rule.match is not None
+#@  assigns: []
+#@end
+spawn_rule = parse_pattern("x -> spawned(x)")


### PR DESCRIPTION
## Summary
- add pattern-rewrite ops: eval, mirror, phase, convolve and spawn
- export the new ops from `ops/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690d21a4dc8329837617bf49af3d03