### PR TITLE
Add sensors, memory, metrics, and governance modules

### DIFF
--- a/lambda_lib/governance/governor.py
+++ b/lambda_lib/governance/governor.py
@@ -1,0 +1,25 @@
+#@module:
+#@  version: "0.3"
+#@  layer: governance
+#@  exposes: [enforce_node_limit]
+#@  doc: Simple governor enforcing graph node limits.
+#@end
+
+from ..graph import Graph
+
+
+#@contract:
+#@  pre: limit >= 0
+#@  post: result in ['ok', 'pruned']
+#@  assigns: [graph.nodes]
+#@end
+def enforce_node_limit(graph: Graph, limit: int) -> str:
+    """Ensure ``graph`` does not exceed ``limit`` nodes."""
+    assert limit >= 0
+    if len(graph.nodes) > limit:
+        graph.nodes = graph.nodes[:limit]
+        result = "pruned"
+    else:
+        result = "ok"
+    assert result in ["ok", "pruned"]
+    return result

--- a/lambda_lib/memory/mem_node.py
+++ b/lambda_lib/memory/mem_node.py
@@ -1,0 +1,28 @@
+#@module:
+#@  version: "0.3"
+#@  layer: memory
+#@  exposes: [MemNode]
+#@  doc: Simple memory node storing a list of items.
+#@end
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MemNode:
+    """In-memory data holder with length tracking."""
+
+    store: list[object] = field(default_factory=list)
+    store_len: int = 0
+
+    #@contract:
+    #@  post: self.store_len >= old_len
+    #@  assigns: [self.store, self.store_len]
+    #@end
+    def add(self, item: object) -> int:
+        """Append ``item`` and update ``store_len``."""
+        old_len = self.store_len
+        self.store.append(item)
+        self.store_len = len(self.store)
+        assert self.store_len >= old_len
+        return self.store_len

--- a/lambda_lib/metrics/accuracy.py
+++ b/lambda_lib/metrics/accuracy.py
@@ -1,0 +1,18 @@
+#@module:
+#@  version: "0.3"
+#@  layer: metrics
+#@  exposes: [accuracy]
+#@  doc: Accuracy metric computation.
+#@end
+
+#@contract:
+#@  post: 0.0 <= result <= 1.0
+#@  assigns: []
+#@end
+def accuracy(preds: list[int], labels: list[int]) -> float:
+    """Return classification accuracy for the given predictions."""
+    total = max(len(labels), 1)
+    correct = sum(1 for p, l in zip(preds, labels) if p == l)
+    result = correct / total
+    assert 0.0 <= result <= 1.0
+    return result

--- a/lambda_lib/metrics/gradient.py
+++ b/lambda_lib/metrics/gradient.py
@@ -1,0 +1,18 @@
+#@module:
+#@  version: "0.3"
+#@  layer: metrics
+#@  exposes: [gradient_norm]
+#@  doc: Simple gradient norm metric.
+#@end
+
+#@contract:
+#@  post: 0.0 <= result <= 1.0
+#@  assigns: []
+#@end
+def gradient_norm(grads: list[float]) -> float:
+    """Return L1 norm of gradients clamped to [0,1]."""
+    norm = sum(abs(g) for g in grads)
+    if norm > 1.0:
+        norm = 1.0
+    assert 0.0 <= norm <= 1.0
+    return norm

--- a/lambda_lib/metrics/reward.py
+++ b/lambda_lib/metrics/reward.py
@@ -1,0 +1,23 @@
+#@module:
+#@  version: "0.3"
+#@  layer: metrics
+#@  exposes: [reward]
+#@  doc: Normalized reward metric.
+#@end
+
+#@contract:
+#@  post: -1.0 <= result <= 1.0
+#@  assigns: []
+#@end
+def reward(value: float, scale: float = 1.0) -> float:
+    """Return a scaled reward clamped to [-1, 1]."""
+    if scale == 0:
+        scaled = 0.0
+    else:
+        scaled = value / scale
+    if scaled > 1.0:
+        scaled = 1.0
+    if scaled < -1.0:
+        scaled = -1.0
+    assert -1.0 <= scaled <= 1.0
+    return scaled

--- a/lambda_lib/sensors/file_tail.py
+++ b/lambda_lib/sensors/file_tail.py
@@ -1,0 +1,34 @@
+#@module:
+#@  version: "0.3"
+#@  layer: sensors
+#@  exposes: [tail_file, TailResult]
+#@  doc: Simple file tailing utility.
+#@end
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class TailResult:
+    """Result of a file tail operation."""
+
+    new_data: str
+    position: int
+
+
+#@contract:
+#@  pre: Path(path).exists()
+#@  post: result.new_data is not None
+#@  assigns: []
+#@end
+def tail_file(path: str, start: int = 0) -> TailResult:
+    """Read file contents from ``start`` and return new data and new position."""
+    assert Path(path).exists()
+    with open(path, "r") as fh:
+        fh.seek(start)
+        data = fh.read()
+        pos = fh.tell()
+    result = TailResult(new_data=data, position=pos)
+    assert result.new_data is not None
+    return result

--- a/lambda_lib/sensors/http_stream.py
+++ b/lambda_lib/sensors/http_stream.py
@@ -1,0 +1,35 @@
+#@module:
+#@  version: "0.3"
+#@  layer: sensors
+#@  exposes: [http_stream, HTTPStreamResult]
+#@  doc: Simple HTTP stream reader.
+#@end
+
+from dataclasses import dataclass
+from urllib.request import urlopen
+from urllib.error import URLError
+
+
+@dataclass
+class HTTPStreamResult:
+    """Result of an HTTP stream fetch."""
+
+    new_data: str
+
+
+#@contract:
+#@  pre: url.startswith("http")
+#@  post: result.new_data is not None
+#@  assigns: []
+#@end
+def http_stream(url: str) -> HTTPStreamResult:
+    """Fetch data from ``url``. Returns empty string on failure."""
+    assert url.startswith("http")
+    try:
+        with urlopen(url) as resp:
+            data = resp.read().decode("utf-8")
+    except Exception:
+        data = ""
+    result = HTTPStreamResult(new_data=data)
+    assert result.new_data is not None
+    return result


### PR DESCRIPTION
## Summary
- implement `tail_file` and `http_stream` sensors
- create `MemNode` memory node with monotonic length
- add accuracy, reward and gradient metrics with bounds
- add `enforce_node_limit` governor to prune large graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690e4c4cd88329b6a94dcf025ca8c6