### PR TITLE
Add scheduler module and CLI

### DIFF
--- a/lambda_lib/cli.py
+++ b/lambda_lib/cli.py
@@ -1,0 +1,48 @@
+#@module:
+#@  version: "0.3"
+#@  layer: app
+#@  exposes: [main]
+#@  doc: Command line interface to run seed λ graphs.
+#@end
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+from .core.engine import LambdaEngine
+from .core.node import LambdaNode
+from .core.operation import LambdaOperation
+from .graph import Graph
+
+
+#@contract:
+#@  pre: len(argv) >= 2
+#@  post: result in [0, 1]
+#@end
+def main(argv: Sequence[str]) -> int:
+    """Run the seed graph specified in ``argv``."""
+    if len(argv) < 2:
+        return 1
+
+    seed = argv[1]
+
+    if seed == "noop":
+        node = LambdaNode("noop")
+        graph = Graph([node])
+
+        def noop_op(n: LambdaNode) -> LambdaNode:
+            return LambdaNode("noop", data=n.data, links=n.links)
+
+        op = LambdaOperation("noop", noop_op)
+
+        engine = LambdaEngine()
+        engine.register(op)
+
+        executor = engine.execute(graph)
+        return 0 if executor.state == "ready" else 1
+
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    sys.exit(main(sys.argv))

--- a/lambda_lib/core/engine.py
+++ b/lambda_lib/core/engine.py
@@ -7,7 +7,7 @@
 from typing import Dict
 
 from ..graph import Graph
-from ..runtime.executor import Executor
+from ..runtime.scheduler import Scheduler
 from .operation import LambdaOperation
 #@contract:
 #@  pre: len(graph.nodes) > 0
@@ -25,7 +25,7 @@ class LambdaEngine:
     def register(self, operation: LambdaOperation) -> None:
         self.registry[operation.name] = operation
 
-    def execute(self, graph: Graph) -> Executor:
+    def execute(self, graph: Graph) -> Scheduler:
         assert len(graph.nodes) > 0
 
         # simple evaluation loop applying registered operations by name
@@ -38,7 +38,7 @@ class LambdaEngine:
             new_nodes.append(node)
         graph.nodes = new_nodes
 
-        executor = Executor(graph)
-        executor.execute()
-        assert executor.state == "ready"
-        return executor
+        scheduler = Scheduler(graph)
+        scheduler.execute()
+        assert scheduler.state == "ready"
+        return scheduler

--- a/lambda_lib/runtime/__init__.py
+++ b/lambda_lib/runtime/__init__.py
@@ -1,7 +1,9 @@
 #@module:
 #@  version: "0.3"
 #@  layer: runtime
-#@  exposes: []
+#@  exposes: [Scheduler]
 #@  doc: Runtime utilities.
 #@end
+
+from .scheduler import Scheduler
 

--- a/lambda_lib/runtime/executor.py
+++ b/lambda_lib/runtime/executor.py
@@ -1,21 +1,2 @@
-#@module:
-#@  version: "0.3"
-#@  layer: runtime
-#@  exposes: [Executor]
-#@  doc: Runtime executor for λ graphs.
-#@end
-from ..graph import Graph
-#@contract:
-#@  pre: self.graph is not None
-#@  post: result == self.graph
-#@  assigns: [self.state]
-#@end
-class Executor:
-    def __init__(self, graph: Graph):
-        self.graph = graph
-        self.state = "init"
-
-    def execute(self) -> Graph:
-        assert self.graph is not None
-        self.state = "ready"
-        return self.graph
+"""Backward compatibility stub for old Executor module."""
+from .scheduler import Scheduler as Executor

--- a/lambda_lib/runtime/scheduler.py
+++ b/lambda_lib/runtime/scheduler.py
@@ -1,0 +1,43 @@
+#@module:
+#@  version: "0.3"
+#@  layer: runtime
+#@  exposes: [Scheduler, Executor]
+#@  doc: Scheduling utilities supporting rule selection strategies.
+#@end
+from __future__ import annotations
+
+import random
+from typing import Iterable, Sequence
+
+from ..graph import Graph
+
+
+class Scheduler:
+    """Simple scheduler that selects rules according to a strategy."""
+
+    def __init__(self, graph: Graph, strategy: str = "fifo") -> None:
+        self.graph = graph
+        self.state = "init"
+        self.strategy = strategy
+
+    def select_rule(self, rules: Sequence[str]) -> str:
+        """Return the next rule name according to the configured strategy."""
+        assert len(rules) > 0
+        rules = list(rules)
+        if self.strategy == "random":
+            return random.choice(rules)
+        return rules[0]
+
+    #@contract:
+    #@  pre: self.graph is not None
+    #@  post: result == self.graph
+    #@  assigns: [self.state]
+    #@end
+    def execute(self) -> Graph:
+        assert self.graph is not None
+        self.state = "ready"
+        return self.graph
+
+
+# Backwards compatibility
+Executor = Scheduler


### PR DESCRIPTION
## Summary
- rename runtime executor to scheduler and add rule selection strategies
- provide backward compatibility stub for Executor
- update engine to use Scheduler
- expose a simple command line interface via `cli.main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690f5b0e7c8329a3ddab71f5c53f4e