### PR TITLE
Add graph visualization and bulk transform helpers

### DIFF
--- a/lambda_lib/graph/transform.py
+++ b/lambda_lib/graph/transform.py
@@ -1,7 +1,7 @@
 #@module:
 #@  version: "0.3"
 #@  layer: graph
-#@  exposes: [transform]
+#@  exposes: [transform, compose_patterns, apply_rules]
 #@  doc: Graph transformation utilities.
 #@end
 #@contract:
@@ -16,3 +16,36 @@ def transform(graph: Graph, rule):
     assert callable(rule)
     new_nodes = [rule(n) for n in graph.nodes]
     return Graph(new_nodes)
+
+
+#@contract:
+#@  pre: len(rules) > 0
+#@  post: callable(result)
+#@  assigns: []
+#@end
+def compose_patterns(*rules):
+    """Return a rule applying all ``rules`` sequentially to a node."""
+    assert len(rules) > 0
+    for r in rules:
+        assert callable(r)
+
+    def composed(node):
+        for r in rules:
+            node = r(node)
+        return node
+
+    return composed
+
+
+#@contract:
+#@  pre:
+#@    - graph is not None
+#@    - len(rules) > 0
+#@  post: result is not None
+#@  assigns: []
+#@end
+def apply_rules(graph: Graph, *rules) -> Graph:
+    """Apply ``rules`` sequentially to all nodes in ``graph``."""
+    assert graph is not None
+    composed = compose_patterns(*rules)
+    return transform(graph, composed)

--- a/lambda_lib/graph/visualize.py
+++ b/lambda_lib/graph/visualize.py
@@ -1,0 +1,48 @@
+#@module:
+#@  version: "0.3"
+#@  layer: graph
+#@  exposes: [render_svg]
+#@  doc: Simple graph visualisation helpers.
+#@end
+from typing import Dict, Tuple
+
+from . import Graph
+
+
+#@contract:
+#@  pre: graph is not None
+#@  post: result.startswith("<svg")
+#@  assigns: []
+#@end
+def render_svg(graph: Graph) -> str:
+    """Return a minimal SVG representation of ``graph``."""
+    assert graph is not None
+
+    width = 120
+    height = 40 * max(len(graph.nodes), 1)
+    positions: Dict[object, Tuple[int, int]] = {}
+    for idx, node in enumerate(graph.nodes):
+        positions[node] = (width // 2, 20 + idx * 40)
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+    ]
+
+    # draw edges
+    for node in graph.nodes:
+        x1, y1 = positions[node]
+        for link in getattr(node, "links", []):
+            if link in positions:
+                x2, y2 = positions[link]
+                parts.append(f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="black"/>')
+
+    # draw nodes
+    for node in graph.nodes:
+        x, y = positions[node]
+        parts.append(f'<circle cx="{x}" cy="{y}" r="10" fill="lightgray" stroke="black"/>')
+        parts.append(f'<text x="{x}" y="{y}" text-anchor="middle" dy="4" font-size="10">{node.label}</text>')
+
+    parts.append("</svg>")
+    result = "\n".join(parts)
+    assert result.startswith("<svg")
+    return result


### PR DESCRIPTION
## Summary
- implement `render_svg` for basic SVG rendering of graphs
- add `compose_patterns` and `apply_rules` helpers to `graph.transform`
- annotate modules with pre/post contracts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869105a7c8083299ef9d9e566c9ea4e