### PR TITLE
Add broad unit test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-vv"

--- a/tests/pattern/test_dsl.py
+++ b/tests/pattern/test_dsl.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+# Ensure project root on path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from lambda_lib.patterns.dsl import parse_pattern, builtin_patterns
+from lambda_lib.core.pattern import Pattern as NodePattern
+from lambda_lib.core.node import LambdaNode
+
+
+def test_parse_pattern():
+    pat = parse_pattern("a -> b")
+    assert pat.match == "a"
+    assert pat.rewrite == "b"
+
+
+def test_builtin_patterns_loaded():
+    # builtin_patterns should contain at least the eval pattern
+    assert "eval" in builtin_patterns
+    assert builtin_patterns["eval"].rewrite == "eval(x)"
+
+
+def test_node_pattern_match():
+    pattern = NodePattern("foo")
+    node_good = LambdaNode("foo")
+    node_bad = LambdaNode("bar")
+    result_good = pattern.match(node_good)
+    result_bad = pattern.match(node_bad)
+    assert result_good.succeeded()
+    assert result_good.matches == [node_good]
+    assert not result_bad.succeeded()
+    assert result_bad.matches == []

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.graph import Graph
+from lambda_lib.governance.governor import enforce_node_limit
+
+
+def test_enforce_node_limit_prunes():
+    nodes = [LambdaNode(str(i)) for i in range(5)]
+    graph = Graph(nodes)
+    result = enforce_node_limit(graph, limit=3)
+    assert result == "pruned"
+    assert len(graph.nodes) == 3
+
+
+def test_enforce_node_limit_ok():
+    nodes = [LambdaNode(str(i)) for i in range(2)]
+    graph = Graph(nodes)
+    result = enforce_node_limit(graph, limit=5)
+    assert result == "ok"
+    assert len(graph.nodes) == 2

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,26 @@
+import pytest
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.metrics.accuracy import accuracy
+from lambda_lib.metrics.gradient import gradient_norm
+from lambda_lib.metrics.reward import reward
+
+
+def test_accuracy_basic():
+    preds = [1, 0, 1]
+    labels = [1, 1, 1]
+    assert accuracy(preds, labels) == pytest.approx(2/3)
+
+
+def test_gradient_norm_clamped():
+    assert gradient_norm([0.5, -0.6]) == 1.0
+    assert gradient_norm([2.0]) == 1.0
+
+
+def test_reward_scaling():
+    assert reward(0.5, scale=1.0) == 0.5
+    assert reward(2.0, scale=1.0) == 1.0
+    assert reward(-3.0, scale=1.0) == -1.0

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.ops import eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule
+
+
+def test_eval_op_parsing():
+    assert eval_rule.match == "x"
+    assert eval_rule.rewrite == "eval(x)"
+
+
+def test_spawn_op_parsing():
+    assert spawn_rule.rewrite == "spawned(x)"
+    assert mirror_rule.rewrite == "x"
+    assert phase_rule.rewrite == "phased(x)"
+    assert convolve_rule.rewrite == "convolved(x)"

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.sensors.file_tail import tail_file
+from lambda_lib.sensors.http_stream import http_stream
+
+
+def test_tail_file(tmp_path):
+    path = tmp_path / "sample.txt"
+    path.write_text("hello\n")
+    res1 = tail_file(str(path))
+    assert res1.new_data == "hello\n"
+    assert res1.position > 0
+    res2 = tail_file(str(path), start=res1.position)
+    assert res2.new_data == ""
+    assert res2.position == res1.position
+
+
+def test_http_stream(monkeypatch):
+    class FakeResp:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def read(self):
+            return b"data"
+
+    def fake_urlopen(url):
+        return FakeResp()
+
+    monkeypatch.setattr("lambda_lib.sensors.http_stream.urlopen", fake_urlopen)
+    res = http_stream("http://example.com")
+    assert res.new_data == "data"
+
+    def raising(url):
+        raise Exception("fail")
+
+    monkeypatch.setattr("lambda_lib.sensors.http_stream.urlopen", raising)
+    res2 = http_stream("http://example.com")
+    assert res2.new_data == ""


### PR DESCRIPTION
## Summary
- add pyproject pytest configuration
- add pattern DSL tests
- cover ops parsing for built‑in rules
- test governor node limit enforcement
- test metrics helper functions
- test sensor utilities for file tail and http fetch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869138d0fb08329ae8540a9ff56c903