### PR TITLE
Add raw sensor support

### DIFF
--- a/lambda_lib/core/engine.py
+++ b/lambda_lib/core/engine.py
@@ -9,6 +9,7 @@ from typing import Dict
 from ..graph import Graph
 from ..runtime.scheduler import Scheduler
 from .operation import LambdaOperation
+from .node import LambdaNode
 #@contract:
 #@  pre: len(graph.nodes) > 0
 #@  post:
@@ -31,9 +32,12 @@ class LambdaEngine:
         # simple evaluation loop applying registered operations by name
         graph.state = "running"
         new_nodes = []
-        for node in graph.nodes:
+        for idx, node in enumerate(graph.nodes):
             operation = self.registry.get(node.label)
-            if operation is not None:
+            if node.raw and node.label == "FeatureMaker":
+                prev_data = new_nodes[idx - 1].data if idx > 0 else None
+                node = LambdaNode(node.label, data=prev_data, links=node.links, raw=node.raw)
+            elif operation is not None:
                 node = operation(node)
             new_nodes.append(node)
         graph.nodes = new_nodes

--- a/lambda_lib/core/node.py
+++ b/lambda_lib/core/node.py
@@ -14,10 +14,11 @@
 class LambdaNode:
     """Basic node in a λ graph."""
 
-    def __init__(self, label: str, data: object | None = None, links: list | None = None) -> None:
+    def __init__(self, label: str, data: object | None = None, links: list | None = None, raw: bool = False) -> None:
         self.label = label
         self.data = data
         self.links = list(links) if links is not None else []
+        self.raw = raw
         self._check_invariants()
 
     # simple alias used by some operations
@@ -39,7 +40,7 @@ class LambdaNode:
     def share(self) -> "LambdaNode":
         """Return a shallow copy of this node."""
         self._check_invariants()
-        clone = LambdaNode(self.label, self.data, self.links)
+        clone = LambdaNode(self.label, self.data, self.links, raw=self.raw)
         clone._check_invariants()
         return clone
 
@@ -54,7 +55,7 @@ class LambdaNode:
         """Return a copy tagged with ``phase``."""
         self._check_invariants()
         new_label = f"{self.label}@{phase}"
-        clone = LambdaNode(new_label, self.data, self.links)
+        clone = LambdaNode(new_label, self.data, self.links, raw=self.raw)
         clone._check_invariants()
         return clone
 
@@ -68,7 +69,7 @@ class LambdaNode:
     def mirror(self) -> "LambdaNode":
         """Return a node with links in reversed order."""
         self._check_invariants()
-        clone = LambdaNode(self.label, self.data, list(reversed(self.links)))
+        clone = LambdaNode(self.label, self.data, list(reversed(self.links)), raw=self.raw)
         clone._check_invariants()
         return clone
 
@@ -76,3 +77,4 @@ class LambdaNode:
         assert self.label is not None
         assert isinstance(self.links, list)
         assert all(isinstance(n, LambdaNode) for n in self.links)
+        assert isinstance(self.raw, bool)

--- a/lambda_lib/examples/classifier/run.py
+++ b/lambda_lib/examples/classifier/run.py
@@ -28,7 +28,7 @@ def load_graph(path: str) -> Graph:
     data = _load(path)
     nodes: list[LambdaNode] = []
     for spec in data.get("nodes", []):
-        node = LambdaNode(spec["label"], spec.get("data"), [])
+        node = LambdaNode(spec["label"], spec.get("data"), [], raw=spec.get("raw", False))
         nodes.append(node)
     # resolve links by index
     for node, spec in zip(nodes, data.get("nodes", [])):

--- a/lambda_lib/examples/classifier/seed.yaml
+++ b/lambda_lib/examples/classifier/seed.yaml
@@ -1,7 +1,7 @@
 {
   "nodes": [
     {"label": "DataStream", "data": 0, "links": []},
-    {"label": "FeatureMaker", "links": [0]},
+    {"label": "FeatureMaker", "links": [0], "raw": true},
     {"label": "Classifier", "links": [1]},
     {"label": "Statistics", "links": [2]}
   ]

--- a/tests/examples/test_classifier.py
+++ b/tests/examples/test_classifier.py
@@ -39,5 +39,7 @@ def test_classifier_example_runs():
     assert scheduler.state == "ready"
     # DataStream node should have incremented value
     assert graph.nodes[0].data == 1
+    # FeatureMaker should bypass processing and carry raw data
+    assert graph.nodes[1].data == 1
     # Classifier node should have produced NORMAL output
     assert graph.nodes[2].data == "NORMAL"


### PR DESCRIPTION
## Summary
- support `raw` nodes that bypass the `FeatureMaker`
- demonstrate raw handling in examples
- cover raw mode with regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691e86c03083298a19ca89766cb335