### PR TITLE
Add feature discovery with governor limits

### DIFF
--- a/lambda_lib/governance/governor.py
+++ b/lambda_lib/governance/governor.py
@@ -1,11 +1,12 @@
 #@module:
 #@  version: "0.3"
 #@  layer: governance
-#@  exposes: [enforce_node_limit]
+#@  exposes: [enforce_node_limit, enforce_feature_limit]
 #@  doc: Simple governor enforcing graph node limits.
 #@end
 
 from ..graph import Graph
+from ..ops.feature_discoverer import FeatureNode
 
 
 #@contract:
@@ -18,6 +19,25 @@ def enforce_node_limit(graph: Graph, limit: int) -> str:
     assert limit >= 0
     if len(graph.nodes) > limit:
         graph.nodes = graph.nodes[:limit]
+        result = "pruned"
+    else:
+        result = "ok"
+    assert result in ["ok", "pruned"]
+    return result
+
+
+#@contract:
+#@  pre: limit >= 0
+#@  post: result in ['ok', 'pruned']
+#@  assigns: [graph.nodes]
+#@end
+def enforce_feature_limit(graph: Graph, limit: int) -> str:
+    """Ensure no more than ``limit`` :class:`FeatureNode` exist in ``graph``."""
+    assert limit >= 0
+    features = [n for n in graph.nodes if isinstance(n, FeatureNode)]
+    if len(features) > limit:
+        excess = features[limit:]
+        graph.nodes = [n for n in graph.nodes if n not in excess]
         result = "pruned"
     else:
         result = "ok"

--- a/lambda_lib/graph/__init__.py
+++ b/lambda_lib/graph/__init__.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, List
 
 from ..core.node import LambdaNode
+from ..ops.feature_discoverer import discover_features
 
 
 @dataclass
@@ -28,5 +29,7 @@ class Graph:
 
     def add(self, node: LambdaNode) -> None:
         self.nodes.append(node)
+        for feature in discover_features(node):
+            self.nodes.append(feature)
         self._check_invariants()
 

--- a/lambda_lib/ops/__init__.py
+++ b/lambda_lib/ops/__init__.py
@@ -1,7 +1,7 @@
 #@module:
 #@  version: "0.3"
 #@  layer: ops
-#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule]
+#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule, FeatureNode, discover_features]
 #@  doc: Package for built‑in λ operations.
 #@end
 
@@ -10,3 +10,4 @@ from .mirror import mirror_rule
 from .phase import phase_rule
 from .convolve import convolve_rule
 from .spawn import spawn_rule
+from .feature_discoverer import FeatureNode, discover_features

--- a/lambda_lib/ops/feature_discoverer.py
+++ b/lambda_lib/ops/feature_discoverer.py
@@ -1,0 +1,44 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [FeatureNode, discover_features]
+#@  doc: Discover new features from node data when accuracy improves.
+#@end
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..core.node import LambdaNode
+
+
+class FeatureNode(LambdaNode):
+    """Specialised LambdaNode representing a discovered feature."""
+
+    def __init__(self, name: str, data: object | None = None):
+        super().__init__(f"Feature:{name}", data, [])
+
+
+# track best accuracy values seen so far
+_best_accuracy: Dict[str, float] = {}
+
+
+#@contract:
+#@  post: isinstance(result, list)
+#@  assigns: [_best_accuracy]
+#@end
+def discover_features(node: LambdaNode) -> List[FeatureNode]:
+    """Return new :class:`FeatureNode` objects if ``node.data`` contains
+    improved accuracy entries.
+    """
+    features: List[FeatureNode] = []
+    if isinstance(node.data, dict):
+        for name, value in node.data.items():
+            try:
+                acc = float(value)
+            except Exception:
+                continue
+            prev = _best_accuracy.get(name, 0.0)
+            if acc > prev:
+                _best_accuracy[name] = acc
+                features.append(FeatureNode(name, acc))
+    return features

--- a/tests/test_feature_discoverer.py
+++ b/tests/test_feature_discoverer.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.graph import Graph
+from lambda_lib.ops.feature_discoverer import FeatureNode, _best_accuracy
+from lambda_lib.governance.governor import enforce_feature_limit
+
+
+def test_feature_discovery_inserts_nodes():
+    _best_accuracy.clear()
+    graph = Graph([])
+    metric = LambdaNode("Metric", data={"clf": 0.6})
+    graph.add(metric)
+    assert any(isinstance(n, FeatureNode) for n in graph.nodes)
+
+    metric2 = LambdaNode("Metric", data={"clf": 0.5})
+    graph.add(metric2)
+    assert len([n for n in graph.nodes if isinstance(n, FeatureNode)]) == 1
+
+    metric3 = LambdaNode("Metric", data={"clf": 0.7})
+    graph.add(metric3)
+    assert len([n for n in graph.nodes if isinstance(n, FeatureNode)]) == 2
+
+
+def test_feature_limit_governor():
+    graph = Graph([LambdaNode("Base")])
+    for i in range(5):
+        graph.add(FeatureNode(f"f{i}", i))
+
+    result = enforce_feature_limit(graph, limit=3)
+    assert result == "pruned"
+    assert len([n for n in graph.nodes if isinstance(n, FeatureNode)]) == 3


### PR DESCRIPTION
## Summary
- implement `FeatureNode` and `discover_features` operation
- automatically insert discovered features when nodes are added
- allow governance module to limit feature nodes
- add unit tests for feature discovery and pruning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68691e7b8a3c83298955cf7cfe021b3d