### PR TITLE
Implement meta rule spawning

### DIFF
--- a/lambda_lib/governance/governor.py
+++ b/lambda_lib/governance/governor.py
@@ -1,12 +1,13 @@
 #@module:
 #@  version: "0.3"
 #@  layer: governance
-#@  exposes: [enforce_node_limit, enforce_feature_limit]
+#@  exposes: [enforce_node_limit, enforce_feature_limit, enforce_rule_limit]
 #@  doc: Simple governor enforcing graph node limits.
 #@end
 
 from ..graph import Graph
 from ..ops.feature_discoverer import FeatureNode
+from ..ops.meta_spawn import RuleNode
 
 
 #@contract:
@@ -37,6 +38,25 @@ def enforce_feature_limit(graph: Graph, limit: int) -> str:
     features = [n for n in graph.nodes if isinstance(n, FeatureNode)]
     if len(features) > limit:
         excess = features[limit:]
+        graph.nodes = [n for n in graph.nodes if n not in excess]
+        result = "pruned"
+    else:
+        result = "ok"
+    assert result in ["ok", "pruned"]
+    return result
+
+
+#@contract:
+#@  pre: limit >= 0
+#@  post: result in ['ok', 'pruned']
+#@  assigns: [graph.nodes]
+#@end
+def enforce_rule_limit(graph: Graph, limit: int) -> str:
+    """Ensure no more than ``limit`` :class:`RuleNode` exist in ``graph``."""
+    assert limit >= 0
+    rules = [n for n in graph.nodes if isinstance(n, RuleNode)]
+    if len(rules) > limit:
+        excess = rules[limit:]
         graph.nodes = [n for n in graph.nodes if n not in excess]
         result = "pruned"
     else:

--- a/lambda_lib/graph/__init__.py
+++ b/lambda_lib/graph/__init__.py
@@ -10,6 +10,7 @@ from typing import Iterable, List
 
 from ..core.node import LambdaNode
 from ..ops.feature_discoverer import discover_features
+from ..ops.meta_spawn import spawn_rules
 
 
 @dataclass
@@ -31,5 +32,7 @@ class Graph:
         self.nodes.append(node)
         for feature in discover_features(node):
             self.nodes.append(feature)
+        for rule in spawn_rules(node):
+            self.nodes.append(rule)
         self._check_invariants()
 

--- a/lambda_lib/ops/__init__.py
+++ b/lambda_lib/ops/__init__.py
@@ -1,7 +1,7 @@
 #@module:
 #@  version: "0.3"
 #@  layer: ops
-#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule, FeatureNode, discover_features]
+#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule, FeatureNode, discover_features, RuleNode, spawn_rules]
 #@  doc: Package for built‑in λ operations.
 #@end
 
@@ -11,3 +11,4 @@ from .phase import phase_rule
 from .convolve import convolve_rule
 from .spawn import spawn_rule
 from .feature_discoverer import FeatureNode, discover_features
+from .meta_spawn import RuleNode, spawn_rules

--- a/lambda_lib/ops/meta_spawn.py
+++ b/lambda_lib/ops/meta_spawn.py
@@ -1,0 +1,44 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [RuleNode, spawn_rules]
+#@  doc: Spawn micro-op rules based on correlation heuristics.
+#@end
+from __future__ import annotations
+
+from typing import List
+
+from ..core.node import LambdaNode
+from ..patterns import parse_pattern
+from ..patterns.dsl import Pattern
+
+
+class RuleNode(LambdaNode):
+    """Specialised LambdaNode representing a spawned rewrite rule."""
+
+    def __init__(self, name: str, pattern: Pattern):
+        super().__init__(f"Rule:{name}", data=pattern, links=[])
+
+
+_DEFAULT_THRESHOLD = 0.8
+
+
+#@contract:
+#@  post: isinstance(result, list)
+#@  assigns: []
+#@end
+def spawn_rules(node: LambdaNode, threshold: float = _DEFAULT_THRESHOLD) -> List[RuleNode]:
+    """Return new :class:`RuleNode` objects if ``node.data`` contains
+    correlations above ``threshold``.
+    """
+    rules: List[RuleNode] = []
+    if isinstance(node.data, dict):
+        for name, value in node.data.items():
+            try:
+                corr = float(value)
+            except Exception:
+                continue
+            if corr >= threshold:
+                pattern = parse_pattern(f"x -> {name}(x)")
+                rules.append(RuleNode(name, pattern))
+    return rules

--- a/tests/test_meta_spawn.py
+++ b/tests/test_meta_spawn.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.graph import Graph
+from lambda_lib.ops.meta_spawn import RuleNode
+from lambda_lib.patterns import parse_pattern
+from lambda_lib.governance.governor import enforce_rule_limit
+
+
+def test_spawn_rules_inserts_nodes():
+    graph = Graph([])
+    metric = LambdaNode("Metric", data={"foo": 0.9, "bar": 0.3})
+    graph.add(metric)
+    rules = [n for n in graph.nodes if isinstance(n, RuleNode)]
+    assert len(rules) == 1
+    assert rules[0].label == "Rule:foo"
+
+
+def test_rule_limit_governor():
+    graph = Graph([LambdaNode("Base")])
+    pat = parse_pattern("x -> y")
+    for i in range(5):
+        graph.add(RuleNode(f"r{i}", pat))
+    result = enforce_rule_limit(graph, limit=2)
+    assert result == "pruned"
+    assert len([n for n in graph.nodes if isinstance(n, RuleNode)]) == 2


### PR DESCRIPTION
## Summary
- add `meta_spawn` operations for generating rules from correlation
- persist spawned rules when adding nodes to the graph
- enforce rule limit through governor
- test rule spawning and spam prevention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686933b838e08329a598027f6f9f067b