### PR TITLE
Add reward metric and reward-guided learning

### DIFF
--- a/lambda_lib/metrics/__init__.py
+++ b/lambda_lib/metrics/__init__.py
@@ -4,3 +4,5 @@
 #@  doc: Metrics collection utilities.
 #@end
 
+from .reward import reward, RewardMetric
+

--- a/lambda_lib/metrics/reward.py
+++ b/lambda_lib/metrics/reward.py
@@ -1,9 +1,11 @@
 #@module:
 #@  version: "0.3"
 #@  layer: metrics
-#@  exposes: [reward]
-#@  doc: Normalized reward metric.
+#@  exposes: [reward, RewardMetric]
+#@  doc: Normalized reward metric and helper node.
 #@end
+
+from ..core.node import LambdaNode
 
 #@contract:
 #@  post: -1.0 <= result <= 1.0
@@ -21,3 +23,15 @@ def reward(value: float, scale: float = 1.0) -> float:
         scaled = -1.0
     assert -1.0 <= scaled <= 1.0
     return scaled
+
+
+class RewardMetric(LambdaNode):
+    """Lambda node storing a normalized reward value."""
+
+    def __init__(self, value: float = 0.0, scale: float = 1.0):
+        super().__init__("RewardMetric", data=reward(value, scale), links=[])
+        self.scale = scale
+
+    def update(self, value: float) -> None:
+        """Update node data with new normalized reward value."""
+        self.data = reward(value, self.scale)

--- a/tests/test_reward_learning.py
+++ b/tests/test_reward_learning.py
@@ -1,0 +1,90 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.engine import LambdaEngine
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.core.operation import LambdaOperation
+from lambda_lib.graph import Graph
+from lambda_lib.metrics.reward import reward
+
+
+def test_reward_guides_model_updates():
+    samples = [
+        {"latency_ms": 500, "label": 1},
+        {"latency_ms": 700, "label": 1},
+    ]
+
+    thresholds = {"Classifier#0": 800, "Classifier#1": 400}
+    idx = 0
+    current_event = None
+    features = None
+    predictions: dict[str, int] = {}
+    reward_values: dict[str, float] = {}
+    classifiers = {"Classifier#0": thresholds["Classifier#0"]}
+
+    def sensor(node: LambdaNode) -> LambdaNode:
+        nonlocal idx, current_event
+        current_event = samples[idx] if idx < len(samples) else None
+        idx += 1
+        return LambdaNode("Sensor", data=current_event, links=node.links)
+
+    def feature_maker(node: LambdaNode) -> LambdaNode:
+        nonlocal features
+        features = None
+        if current_event:
+            features = {"latency_ms": current_event["latency_ms"]}
+        return LambdaNode("FeatureMaker", data=features, links=node.links)
+
+    def make_classifier(name: str, thr: int):
+        def classifier(node: LambdaNode) -> LambdaNode:
+            pred = None
+            if features is not None:
+                pred = int(features["latency_ms"] >= thr)
+                predictions[name] = pred
+            return LambdaNode(name, data=pred, links=node.links)
+        return classifier
+
+    def metric(node: LambdaNode) -> LambdaNode:
+        if current_event:
+            true_label = current_event["label"]
+            for cname in list(classifiers.keys()):
+                pred = predictions.get(cname)
+                if pred is not None:
+                    val = 1.0 if pred == true_label else -1.0
+                    reward_values[cname] = reward(val)
+        return LambdaNode("RewardMetric", data=reward_values.copy(), links=node.links)
+
+    engine = LambdaEngine()
+    engine.register(LambdaOperation("Sensor", sensor))
+    engine.register(LambdaOperation("FeatureMaker", feature_maker))
+    engine.register(LambdaOperation("Classifier#0", make_classifier("Classifier#0", thresholds["Classifier#0"])))
+    engine.register(LambdaOperation("RewardMetric", metric))
+
+    graph = Graph([
+        LambdaNode("Sensor"),
+        LambdaNode("FeatureMaker"),
+        LambdaNode("Classifier#0"),
+        LambdaNode("RewardMetric"),
+    ])
+
+    for _ in samples:
+        engine.execute(graph)
+
+        if "Classifier#1" not in classifiers and reward_values.get("Classifier#0", 0) < 0:
+            classifiers["Classifier#1"] = thresholds["Classifier#1"]
+            engine.register(LambdaOperation("Classifier#1", make_classifier("Classifier#1", thresholds["Classifier#1"])))
+            new_node = LambdaNode("Classifier#1")
+            graph.nodes.insert(len(graph.nodes) - 1, new_node)
+
+        if "Classifier#1" in classifiers and "Classifier#0" in classifiers:
+            if reward_values.get("Classifier#1", -1) > reward_values.get("Classifier#0", -1):
+                graph.nodes = [n for n in graph.nodes if n.label != "Classifier#0"]
+                engine.registry.pop("Classifier#0", None)
+                classifiers.pop("Classifier#0", None)
+
+    classifier_labels = [n.label for n in graph.nodes if n.label.startswith("Classifier")]
+    assert "Classifier#1" in classifier_labels
+    assert "Classifier#0" not in classifier_labels
+    assert any(n.label == "RewardMetric" for n in graph.nodes)


### PR DESCRIPTION
## Summary
- introduce a RewardMetric LambdaNode using the `reward` utility
- expose RewardMetric in `lambda_lib.metrics`
- add new tests exercising reward-guided model updates without labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686935d0f66c832988697db42e3c276c