### PR TITLE
Add sequence memory with context operation

### DIFF
--- a/lambda_lib/memory/__init__.py
+++ b/lambda_lib/memory/__init__.py
@@ -4,3 +4,7 @@
 #@  doc: Memory management primitives.
 #@end
 
+from .mem_node import MemNode
+from .sequence import SequenceMemory, convolve_context
+
+__all__ = ["MemNode", "SequenceMemory", "convolve_context"]

--- a/lambda_lib/memory/sequence.py
+++ b/lambda_lib/memory/sequence.py
@@ -1,0 +1,55 @@
+#@module:
+#@  version: "0.3"
+#@  layer: memory
+#@  exposes: [SequenceMemory, convolve_context]
+#@  doc: FIFO memory for storing recent events and simple context-aware update.
+#@end
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from collections import deque
+from statistics import mean
+
+
+@dataclass
+class SequenceMemory:
+    """Fixed-size queue tracking the most recent items."""
+
+    capacity: int = 10
+    events: deque = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.events = deque(maxlen=self.capacity)
+
+    #@contract:
+    #@  post: len(self.events) <= self.capacity
+    #@  assigns: [self.events]
+    #@end
+    def push(self, item: object) -> None:
+        """Add ``item`` keeping at most ``capacity`` items."""
+        self.events.append(item)
+        assert len(self.events) <= self.capacity
+
+    def __len__(self) -> int:
+        return len(self.events)
+
+    def as_list(self) -> list:
+        """Return memory contents oldest first."""
+        return list(self.events)
+
+
+#@contract:
+#@  pre: memory is not None
+#@  post: result is not None
+#@  assigns: []
+#@end
+def convolve_context(pred: float, memory: SequenceMemory, weight: float = 0.5) -> float:
+    """Blend ``pred`` with the mean of ``memory`` using ``weight``."""
+    assert memory is not None
+    if len(memory) == 0:
+        return pred
+    ctx = mean(memory.as_list())
+    result = weight * pred + (1 - weight) * ctx
+    assert result is not None
+    return result

--- a/tests/test_sequence_memory.py
+++ b/tests/test_sequence_memory.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.memory.sequence import SequenceMemory, convolve_context
+
+
+def test_sequence_memory_push_and_limit():
+    mem = SequenceMemory(capacity=3)
+    for i in range(5):
+        mem.push(i)
+    assert len(mem) == 3
+    assert mem.as_list() == [2, 3, 4]
+
+
+def test_n_step_reward_influences_learning():
+    labels = [1, 0, 1, 1]
+    memory = SequenceMemory(capacity=2)
+    weight_nomem = 0.0
+    weight_mem = 0.0
+    preds_nomem = []
+    preds_mem = []
+
+    for t, label in enumerate(labels):
+        p_nomem = int(weight_nomem > 0.5)
+        preds_nomem.append(p_nomem)
+        p_mem = int(weight_mem > 0.5)
+        preds_mem.append(p_mem)
+        if t >= 2:
+            r = 1.0 if preds_mem[t-2] == labels[t-2] else -1.0
+            memory.push(r)
+            weight_mem = convolve_context(weight_mem, memory, weight=0.5)
+
+    for t in range(len(labels) - 2, len(labels)):
+        r = 1.0 if preds_mem[t] == labels[t] else -1.0
+        memory.push(r)
+        weight_mem = convolve_context(weight_mem, memory, weight=0.5)
+
+    assert weight_nomem == 0.0
+    assert weight_mem != weight_nomem
+


### PR DESCRIPTION
## Summary
- implement `SequenceMemory` for FIFO event storage
- expose `convolve_context` blending predictions with memory
- export memory helpers in package `__init__`
- test `SequenceMemory` capacity and influence of delayed rewards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869376d25d4832988004828d03cdffe