### PR TITLE
Add RefactorOp for graph cleanup

### DIFF
--- a/lambda_lib/ops/__init__.py
+++ b/lambda_lib/ops/__init__.py
@@ -1,7 +1,7 @@
 #@module:
 #@  version: "0.3"
 #@  layer: ops
-#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule, FeatureNode, discover_features, RuleNode, spawn_rules]
+#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule, FeatureNode, discover_features, RuleNode, spawn_rules, RefactorOp]
 #@  doc: Package for built‑in λ operations.
 #@end
 
@@ -12,3 +12,4 @@ from .convolve import convolve_rule
 from .spawn import spawn_rule
 from .feature_discoverer import FeatureNode, discover_features
 from .meta_spawn import RuleNode, spawn_rules
+from .refactor import RefactorOp

--- a/lambda_lib/ops/refactor.py
+++ b/lambda_lib/ops/refactor.py
@@ -1,0 +1,69 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [RefactorOp]
+#@  doc: Graph cleanup operation removing duplicates and dead branches.
+#@end
+from __future__ import annotations
+
+import math
+from typing import Dict, Tuple, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..graph import Graph
+
+from ..core.node import LambdaNode
+
+
+class RefactorOp:
+    """Deduplicate nodes and prune unused branches based on entropy."""
+
+    def __init__(self, entropy_threshold: float = 1.0) -> None:
+        self.entropy_threshold = entropy_threshold
+
+    def _entropy(self, counts: Dict[str, int]) -> float:
+        total = sum(counts.values())
+        if total == 0:
+            return 0.0
+        ent = 0.0
+        for c in counts.values():
+            p = c / total
+            if p > 0:
+                ent -= p * math.log2(p)
+        return ent
+
+    #@contract:
+    #@  pre: graph is not None
+    #@  post: result is graph
+    #@  assigns: [graph.nodes]
+    #@end
+    def __call__(self, graph: 'Graph') -> 'Graph':
+        from ..graph import Graph  # local import to avoid circular dependency
+
+        assert graph is not None
+        counts: Dict[str, int] = {}
+        for n in graph.nodes:
+            counts[n.label] = counts.get(n.label, 0) + 1
+        ent = self._entropy(counts)
+        if ent <= self.entropy_threshold:
+            # deduplicate by label and data
+            new_nodes: list[LambdaNode] = []
+            seen: Set[Tuple[str, str]] = set()
+            for n in graph.nodes:
+                key = (n.label, repr(n.data))
+                if key in seen:
+                    continue
+                seen.add(key)
+                new_nodes.append(n)
+
+            # compute usage counts
+            usage: Dict[LambdaNode, int] = {n: 0 for n in new_nodes}
+            for n in new_nodes:
+                for link in n.links:
+                    if link in usage:
+                        usage[link] += 1
+
+            # remove nodes that have no links and are unused
+            new_nodes = [n for n in new_nodes if n.links or usage[n] > 0]
+            graph.nodes = new_nodes
+        return graph

--- a/tests/test_refactor_op.py
+++ b/tests/test_refactor_op.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.graph import Graph
+from lambda_lib.ops.refactor import RefactorOp
+
+
+def test_refactor_prunes_duplicates_and_dead_nodes():
+    n1 = LambdaNode("A")
+    n2 = LambdaNode("A")  # duplicate
+    n3 = LambdaNode("B")
+    n1.add_link(n3)
+    dead = LambdaNode("C")
+    graph = Graph([n1, n2, n3, dead])
+    initial = len(graph.nodes)
+    RefactorOp(entropy_threshold=2.0)(graph)
+    assert len(graph.nodes) < initial
+    labels = [n.label for n in graph.nodes]
+    assert labels.count("A") == 1
+    assert "C" not in labels


### PR DESCRIPTION
## Summary
- add `RefactorOp` operation for deduplication and branch pruning
- expose `RefactorOp` through `lambda_lib.ops`
- test cleanup on a graph with redundant nodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686938fc2fb483298709f3add7da6eb0