### PR TITLE
Add MetaGovernor for adaptive limit tuning

### DIFF
--- a/lambda_lib/governance/__init__.py
+++ b/lambda_lib/governance/__init__.py
@@ -4,3 +4,5 @@
 #@  doc: Governance policy layer.
 #@end
 
+from .governor import enforce_node_limit, enforce_feature_limit, enforce_rule_limit
+from .meta_governor import MetaGovernor

--- a/lambda_lib/governance/meta_governor.py
+++ b/lambda_lib/governance/meta_governor.py
@@ -1,0 +1,52 @@
+#@module:
+#@  version: "0.3"
+#@  layer: governance
+#@  exposes: [MetaGovernor]
+#@  doc: Adaptive governor adjusting limits based on reward and resource cost.
+#@end
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..graph import Graph
+from .governor import enforce_node_limit, enforce_rule_limit
+
+
+@dataclass
+class MetaGovernor:
+    """Adaptive governor that tunes node and rule limits."""
+
+    node_limit: int = 10
+    rule_limit: int = 5
+    cpu_limit: float = 1.0
+    ram_limit: float = 1.0
+    graph_limit: int = 100
+
+    def _cost(self, cpu: float, ram: float, graph_size: int) -> float:
+        cost = 0.0
+        if self.cpu_limit:
+            cost += cpu / self.cpu_limit
+        if self.ram_limit:
+            cost += ram / self.ram_limit
+        if self.graph_limit:
+            cost += graph_size / self.graph_limit
+        return cost
+
+    def evaluate(self, reward: float, cpu: float, ram: float, graph: Graph) -> None:
+        """Update limits based on reward to cost ratio."""
+        cost = self._cost(cpu, ram, len(graph.nodes))
+        if cost <= 0:
+            ratio = reward
+        else:
+            ratio = reward / cost
+        if ratio < 1.0:
+            self.node_limit = max(1, self.node_limit - 1)
+            self.rule_limit = max(1, self.rule_limit - 1)
+        else:
+            self.node_limit += 1
+            self.rule_limit += 1
+
+    def govern(self, graph: Graph) -> None:
+        """Apply current limits to ``graph``."""
+        enforce_node_limit(graph, self.node_limit)
+        enforce_rule_limit(graph, self.rule_limit)

--- a/tests/test_meta_governor.py
+++ b/tests/test_meta_governor.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.graph import Graph
+from lambda_lib.ops.meta_spawn import RuleNode
+from lambda_lib.patterns import parse_pattern
+from lambda_lib.governance.meta_governor import MetaGovernor
+
+
+def test_meta_governor_tightens_on_high_cost():
+    graph = Graph([LambdaNode(str(i)) for i in range(5)])
+    pat = parse_pattern("x -> y")
+    for i in range(3):
+        graph.add(RuleNode(f"r{i}", pat))
+
+    mg = MetaGovernor(node_limit=5, rule_limit=3, cpu_limit=1.0, ram_limit=1.0, graph_limit=10)
+    mg.evaluate(reward=0.2, cpu=2.0, ram=2.0, graph=graph)
+    mg.govern(graph)
+
+    assert mg.node_limit == 4
+    assert mg.rule_limit == 2
+    assert len(graph.nodes) <= mg.node_limit
+    assert len([n for n in graph.nodes if isinstance(n, RuleNode)]) <= mg.rule_limit
+
+
+def test_meta_governor_relaxes_on_low_cost():
+    graph = Graph([LambdaNode("base")])
+    mg = MetaGovernor(node_limit=1, rule_limit=1, cpu_limit=1.0, ram_limit=1.0, graph_limit=10)
+    mg.evaluate(reward=2.0, cpu=0.1, ram=0.1, graph=graph)
+
+    assert mg.node_limit == 2
+    assert mg.rule_limit == 2


### PR DESCRIPTION
## Summary
- implement `MetaGovernor` to dynamically tighten or loosen node/rule limits
- expose adaptive governor through `governance` package
- test meta-governor behaviour under high and low cost scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693c2a4c2083298f71694c141f8cd6