### PR TITLE
Add collaboration ops for model voting

### DIFF
--- a/lambda_lib/examples/collaboration/README.md
+++ b/lambda_lib/examples/collaboration/README.md
@@ -1,0 +1,7 @@
+# Collaboration Example
+
+Demonstrates a graph where multiple classifier nodes vote on
+predictions before computing reward.
+
+Run `python -m lambda_lib.examples.collaboration.run` to execute
+with the default sample stream.

--- a/lambda_lib/examples/collaboration/__init__.py
+++ b/lambda_lib/examples/collaboration/__init__.py
@@ -1,0 +1,6 @@
+#@module:
+#@  version: "0.3"
+#@  layer: examples
+#@  doc: Example of collaborative classifiers using voting.
+#@end
+

--- a/lambda_lib/examples/collaboration/run.py
+++ b/lambda_lib/examples/collaboration/run.py
@@ -1,0 +1,103 @@
+#@module:
+#@  version: "0.3"
+#@  layer: examples
+#@  exposes: [build_graph]
+#@  doc: Build a graph of collaborative classifiers using vote op.
+#@end
+from __future__ import annotations
+
+from typing import List, Dict, Tuple
+
+from ...core.engine import LambdaEngine
+from ...core.node import LambdaNode
+from ...core.operation import LambdaOperation
+from ...graph import Graph
+from ...metrics.reward import reward
+from ...models.classifier import RuleBasedClassifier
+from ...ops.collaboration import vote
+
+
+def build_graph(samples: List[Dict], thresholds: List[int]) -> Tuple[LambdaEngine, Graph, Dict[str, List[float]], List[float]]:
+    """Return engine, graph and reward histories for individual and ensemble models."""
+    idx = 0
+    current: Dict | None = None
+    features: Dict | None = None
+    preds: Dict[str, int] = {}
+    rewards: Dict[str, List[float]] = {f"Model#{t}": [] for t in thresholds}
+    ensemble_rewards: List[float] = []
+    models = {f"Model#{t}": RuleBasedClassifier(t) for t in thresholds}
+
+    def sensor(node: LambdaNode) -> LambdaNode:
+        nonlocal idx, current
+        current = samples[idx] if idx < len(samples) else None
+        idx += 1
+        return LambdaNode("Sensor", data=current, links=node.links)
+
+    def feature_maker(node: LambdaNode) -> LambdaNode:
+        nonlocal features
+        features = None
+        if current:
+            features = {"latency_ms": current.get("latency_ms", 0), "label": current.get("label", 0)}
+        return LambdaNode("FeatureMaker", data=features, links=node.links)
+
+    def make_model(name: str, model: RuleBasedClassifier):
+        def model_op(node: LambdaNode) -> LambdaNode:
+            pred = None
+            if features is not None:
+                pred = model.predict(features)
+                preds[name] = pred
+            return LambdaNode(name, data=pred, links=node.links)
+        return model_op
+
+    def vote_node(node: LambdaNode) -> LambdaNode:
+        if preds:
+            result = vote(list(preds.values()))
+        else:
+            result = None
+        preds["Vote"] = result if result is not None else 0
+        return LambdaNode("Vote", data=result, links=node.links)
+
+    def metric(node: LambdaNode) -> LambdaNode:
+        if features:
+            label = int(features["label"])
+            for name in models:
+                pred = preds.get(name)
+                if pred is not None:
+                    val = 1.0 if pred == label else -1.0
+                    rewards[name].append(reward(val))
+            vote_pred = preds.get("Vote")
+            if vote_pred is not None:
+                ensemble_rewards.append(reward(1.0 if vote_pred == label else -1.0))
+        return LambdaNode("RewardMetric", data=None, links=node.links)
+
+    engine = LambdaEngine()
+    engine.register(LambdaOperation("Sensor", sensor))
+    engine.register(LambdaOperation("FeatureMaker", feature_maker))
+    for name, model in models.items():
+        engine.register(LambdaOperation(name, make_model(name, model)))
+    engine.register(LambdaOperation("Vote", vote_node))
+    engine.register(LambdaOperation("RewardMetric", metric))
+
+    graph = Graph([
+        LambdaNode("Sensor"),
+        LambdaNode("FeatureMaker"),
+        *[LambdaNode(name) for name in models],
+        LambdaNode("Vote"),
+        LambdaNode("RewardMetric"),
+    ])
+
+    return engine, graph, rewards, ensemble_rewards
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    samples = [
+        {"latency_ms": 100, "label": 0},
+        {"latency_ms": 700, "label": 1},
+        {"latency_ms": 400, "label": 0},
+        {"latency_ms": 900, "label": 1},
+    ]
+    engine, graph, rewards, ensemble = build_graph(samples, [800, 500])
+    for _ in samples:
+        engine.execute(graph)
+    print("ensemble rewards", ensemble)
+

--- a/lambda_lib/ops/__init__.py
+++ b/lambda_lib/ops/__init__.py
@@ -1,7 +1,9 @@
 #@module:
 #@  version: "0.3"
 #@  layer: ops
-#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule, FeatureNode, discover_features, RuleNode, spawn_rules, RefactorOp]
+#@  exposes: [eval_rule, mirror_rule, phase_rule, convolve_rule, spawn_rule,
+#@            FeatureNode, discover_features, RuleNode, spawn_rules,
+#@            RefactorOp, vote, merge_models, convolve]
 #@  doc: Package for built‑in λ operations.
 #@end
 
@@ -13,3 +15,4 @@ from .spawn import spawn_rule
 from .feature_discoverer import FeatureNode, discover_features
 from .meta_spawn import RuleNode, spawn_rules
 from .refactor import RefactorOp
+from .collaboration import vote, merge_models, convolve

--- a/lambda_lib/ops/collaboration.py
+++ b/lambda_lib/ops/collaboration.py
@@ -1,0 +1,52 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [vote, merge_models, convolve]
+#@  doc: Cooperative operations for model ensembles.
+#@end
+from __future__ import annotations
+
+from statistics import mean
+from typing import Iterable, Sequence
+
+from ..models.classifier import RuleBasedClassifier
+
+
+#@contract:
+#@  pre: all(p in (0, 1) for p in preds)
+#@  post: result in (0, 1)
+#@  assigns: []
+#@end
+def vote(preds: Iterable[int]) -> int:
+    """Return majority class from ``preds``."""
+    vals = list(preds)
+    assert len(vals) > 0
+    ones = sum(1 for p in vals if p == 1)
+    return int(ones >= len(vals) / 2)
+
+
+#@contract:
+#@  pre: len(list(models)) > 0
+#@  post: isinstance(result, RuleBasedClassifier)
+#@  assigns: []
+#@end
+def merge_models(models: Iterable[RuleBasedClassifier]) -> RuleBasedClassifier:
+    """Return a new classifier averaging model thresholds."""
+    mlist = list(models)
+    assert len(mlist) > 0
+    thr = int(round(mean(m.threshold for m in mlist)))
+    return RuleBasedClassifier(threshold=thr)
+
+
+#@contract:
+#@  pre: len(values) > 0
+#@  post: result is not None
+#@  assigns: []
+#@end
+def convolve(values: Sequence[float], weight: float = 0.5) -> float:
+    """Blend last value with previous mean using ``weight``."""
+    assert len(values) > 0
+    if len(values) == 1:
+        return values[0]
+    prev_mean = mean(values[:-1])
+    return weight * values[-1] + (1 - weight) * prev_mean

--- a/tests/test_collaboration_ops.py
+++ b/tests/test_collaboration_ops.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.metrics.reward import reward
+from lambda_lib.models.classifier import RuleBasedClassifier
+from lambda_lib.ops.collaboration import vote, merge_models, convolve
+
+
+def test_vote_majority():
+    assert vote([0, 1, 1]) == 1
+    assert vote([0, 0, 1]) == 0
+
+
+def test_merge_models_averages_threshold():
+    a = RuleBasedClassifier(1000)
+    b = RuleBasedClassifier(500)
+    merged = merge_models([a, b])
+    assert isinstance(merged, RuleBasedClassifier)
+    assert merged.threshold == 750
+
+
+def test_convolve_blends_values():
+    vals = [0.0, 1.0, 1.0]
+    result = convolve(vals, weight=0.5)
+    assert result == 0.5 * vals[-1] + 0.5 * sum(vals[:-1]) / (len(vals) - 1)
+
+
+def test_ensemble_reward_exceeds_individual():
+    samples = [
+        {"latency_ms": 500, "label": 1},
+        {"latency_ms": 900, "label": 1},
+        {"latency_ms": 300, "label": 0},
+        {"latency_ms": 1100, "label": 1},
+    ]
+    clf_a = RuleBasedClassifier(800)
+    clf_b = RuleBasedClassifier(400)
+    rewards_a = []
+    rewards_b = []
+    rewards_vote = []
+    for s in samples:
+        f = {"latency_ms": s["latency_ms"]}
+        pa = clf_a.predict(f)
+        pb = clf_b.predict(f)
+        pv = vote([pa, pb])
+        label = s["label"]
+        rewards_a.append(reward(1.0 if pa == label else -1.0))
+        rewards_b.append(reward(1.0 if pb == label else -1.0))
+        rewards_vote.append(reward(1.0 if pv == label else -1.0))
+    avg_a = sum(rewards_a) / len(rewards_a)
+    avg_b = sum(rewards_b) / len(rewards_b)
+    avg_vote = sum(rewards_vote) / len(rewards_vote)
+    assert avg_vote >= max(avg_a, avg_b)
+


### PR DESCRIPTION
## Summary
- implement new `vote`, `merge_models` and `convolve` operations
- expose new operations through `lambda_lib.ops`
- add example ensemble graph demonstrating classifier voting
- test collaboration utilities and ensemble reward behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693d024c108329ba1939e4d409477e