### PR TITLE
Add concept node and discovery

### DIFF
--- a/lambda_lib/core/node.py
+++ b/lambda_lib/core/node.py
@@ -1,7 +1,7 @@
 #@module:
 #@  version: "0.3"
 #@  layer: core
-#@  exposes: [LambdaNode]
+#@  exposes: [LambdaNode, ConceptNode]
 #@  doc: Fundamental λ entity representing a unit of meaning.
 #@end
 #@contract:
@@ -78,3 +78,12 @@ class LambdaNode:
         assert isinstance(self.links, list)
         assert all(isinstance(n, LambdaNode) for n in self.links)
         assert isinstance(self.raw, bool)
+
+
+class ConceptNode(LambdaNode):
+    """Lambda node representing an emergent concept."""
+
+    def __init__(self, name: str, correlation: float) -> None:
+        metadata = {name: correlation}
+        super().__init__(f"Concept:{name}", data=metadata, links=[])
+        self.metadata = {"correlation": correlation}

--- a/lambda_lib/graph/__init__.py
+++ b/lambda_lib/graph/__init__.py
@@ -12,6 +12,7 @@ from ..core.node import LambdaNode
 from ..ops.feature_discoverer import discover_features
 from ..ops.meta_spawn import spawn_rules
 from ..ops.model_spawner import spawn_models
+from ..ops.concept_inventor import spawn_concepts
 
 
 @dataclass
@@ -37,5 +38,9 @@ class Graph:
             self.nodes.append(rule)
         for model in spawn_models(node):
             self.nodes.append(model)
+        for concept in spawn_concepts(node):
+            self.nodes.append(concept)
+            for rule in spawn_rules(concept):
+                self.nodes.append(rule)
         self._check_invariants()
 

--- a/lambda_lib/ops/concept_inventor.py
+++ b/lambda_lib/ops/concept_inventor.py
@@ -1,0 +1,33 @@
+#@module:
+#@  version: "0.3"
+#@  layer: ops
+#@  exposes: [spawn_concepts]
+#@  doc: Spawn ConceptNode objects when correlations exceed a threshold.
+#@end
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..core.node import LambdaNode, ConceptNode
+
+_DEFAULT_CONCEPT_THRESHOLD = 0.9
+
+_best_corr: Dict[str, float] = {}
+
+
+def spawn_concepts(node: LambdaNode, threshold: float = _DEFAULT_CONCEPT_THRESHOLD) -> List[ConceptNode]:
+    """Return new ConceptNode objects if ``node.data`` contains
+    correlation values above ``threshold``.
+    """
+    concepts: List[ConceptNode] = []
+    if isinstance(node.data, dict):
+        for name, value in node.data.items():
+            try:
+                corr = float(value)
+            except Exception:
+                continue
+            prev = _best_corr.get(name, float("-inf"))
+            if corr >= threshold and corr > prev:
+                _best_corr[name] = corr
+                concepts.append(ConceptNode(name, corr))
+    return concepts

--- a/tests/test_concept_inventor.py
+++ b/tests/test_concept_inventor.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lambda_lib.core.node import LambdaNode, ConceptNode
+from lambda_lib.graph import Graph
+from lambda_lib.ops.concept_inventor import _best_corr
+from lambda_lib.ops.meta_spawn import RuleNode
+
+
+def test_concept_spawn_creates_nodes_and_rules():
+    _best_corr.clear()
+    graph = Graph([])
+    metric = LambdaNode("Metric", data={"foo": 0.95})
+    graph.add(metric)
+    concepts = [n for n in graph.nodes if isinstance(n, ConceptNode)]
+    rules = [n for n in graph.nodes if isinstance(n, RuleNode)]
+    assert any(c.label == "Concept:foo" for c in concepts)
+    assert any(r.label == "Rule:foo" for r in rules)


### PR DESCRIPTION
## Summary
- introduce `ConceptNode` for emergent concepts
- implement `spawn_concepts` operation
- extend `Graph.add` to spawn concept nodes and rules
- test concept discovery and rule generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693e4de5e88329b543600087935f5d