### PR TITLE
Add feature discoverer with statistics

### DIFF
--- a/lambda_lib/graph/__init__.py
+++ b/lambda_lib/graph/__init__.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass, field
 from typing import Iterable, List
 
 from ..core.node import LambdaNode
-from ..ops.feature_discoverer import discover_features
+from ..ops.feature_discoverer import discover_features, discover
+from ..ops.spawn_feature import spawn_feature
 from ..ops.meta_spawn import spawn_rules
 from ..ops.model_spawner import spawn_models
 from ..ops.concept_inventor import spawn_concepts
@@ -32,6 +33,11 @@ class Graph:
 
     def add(self, node: LambdaNode) -> None:
         self.nodes.append(node)
+        if isinstance(node.data, dict) and "label" in node.data:
+            for expr in discover([node]):
+                self.nodes.append(
+                    spawn_feature(LambdaNode("FeatureDiscoverer", data={"expr": expr}))
+                )
         for feature in discover_features(node):
             self.nodes.append(feature)
         for rule in spawn_rules(node):

--- a/lambda_lib/ops/__init__.py
+++ b/lambda_lib/ops/__init__.py
@@ -12,7 +12,7 @@ from .mirror import mirror_rule
 from .phase import phase_rule
 from .convolve import convolve_rule
 from .spawn import spawn_rule
-from .feature_discoverer import FeatureNode, discover_features
+from .feature_discoverer import FeatureNode, discover_features, discover
 from .spawn_feature import spawn_feature
 from .meta_spawn import RuleNode, spawn_rules
 from .refactor import RefactorOp

--- a/lambda_lib/ops/feature_discoverer.py
+++ b/lambda_lib/ops/feature_discoverer.py
@@ -1,12 +1,16 @@
 #@module:
 #@  version: "0.3"
 #@  layer: ops
-#@  exposes: [FeatureNode, discover_features]
+#@  exposes: [FeatureNode, discover_features, discover]
 #@  doc: Discover new features from node data when accuracy improves.
 #@end
 from __future__ import annotations
 
 from typing import Dict, List
+from statistics import pvariance, mean, pstdev
+import math
+
+from ..memory import SequenceMemory
 
 from ..core.node import LambdaNode
 
@@ -20,6 +24,8 @@ class FeatureNode(LambdaNode):
 
 # track best accuracy values seen so far
 _best_accuracy: Dict[str, float] = {}
+
+_event_memory = SequenceMemory(capacity=10)
 
 
 #@contract:
@@ -42,3 +48,51 @@ def discover_features(node: LambdaNode) -> List[FeatureNode]:
                 _best_accuracy[name] = acc
                 features.append(FeatureNode(name, acc))
     return features
+
+
+def _point_biserial(values: List[float], labels: List[int]) -> float:
+    if len(values) != len(labels):
+        return 0.0
+    n = len(values)
+    n1 = sum(1 for l in labels if l == 1)
+    n0 = n - n1
+    if n0 == 0 or n1 == 0:
+        return 0.0
+    m1 = mean(v for v, lbl in zip(values, labels) if lbl == 1)
+    m0 = mean(v for v, lbl in zip(values, labels) if lbl == 0)
+    s = pstdev(values)
+    if s == 0:
+        return 0.0
+    return (m1 - m0) / s * math.sqrt(n1 * n0 / (n * n))
+
+
+def discover(node_batch: List[LambdaNode]) -> List[str]:
+    """Return feature expression candidates discovered from ``node_batch``."""
+    candidates: List[str] = []
+    if not node_batch:
+        return candidates
+
+    for node in node_batch:
+        if isinstance(node.data, dict) and "label" in node.data:
+            _event_memory.push(node.data)
+
+    events = _event_memory.as_list()
+    if len(events) < 2:
+        return candidates
+
+    labels = [int(e["label"]) for e in events if "label" in e]
+    if len(labels) != len(events) or len(set(labels)) < 2:
+        return candidates
+
+    keys = [k for k in events[0].keys() if k != "label"]
+    for key in keys:
+        try:
+            vals = [float(e[key]) for e in events]
+        except Exception:
+            continue
+        var = pvariance(vals)
+        corr = _point_biserial(vals, labels)
+        if var > 0 and abs(corr) > 0:
+            candidates.append(str(key))
+
+    return candidates


### PR DESCRIPTION
## Summary
- update `feature_discoverer` with a new `discover` API
- expose new method from ops package
- insert discovered features automatically in `Graph.add`
- extend feature discoverer tests with batch discovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869445218c083298092373b28e8d1c3