### PR TITLE
Add adaptive feature/rule limits

### DIFF
--- a/lambda_lib/governance/governor.py
+++ b/lambda_lib/governance/governor.py
@@ -28,13 +28,24 @@ def enforce_node_limit(graph: Graph, limit: int) -> str:
 
 
 #@contract:
-#@  pre: limit >= 0
+#@  pre:
+#@    - limit >= 0
+#@    - max_features is None or max_features >= 0
 #@  post: result in ['ok', 'pruned']
 #@  assigns: [graph.nodes]
 #@end
-def enforce_feature_limit(graph: Graph, limit: int) -> str:
-    """Ensure no more than ``limit`` :class:`FeatureNode` exist in ``graph``."""
+def enforce_feature_limit(
+    graph: Graph, limit: int, max_features: int | None = None
+) -> str:
+    """Ensure the number of :class:`FeatureNode` objects does not exceed ``limit``.
+
+    If ``max_features`` is provided, it represents a hard cap that ``limit``
+    cannot exceed.
+    """
     assert limit >= 0
+    if max_features is not None:
+        assert max_features >= 0
+        limit = min(limit, max_features)
     features = [n for n in graph.nodes if isinstance(n, FeatureNode)]
     if len(features) > limit:
         excess = features[limit:]
@@ -47,13 +58,23 @@ def enforce_feature_limit(graph: Graph, limit: int) -> str:
 
 
 #@contract:
-#@  pre: limit >= 0
+#@  pre:
+#@    - limit >= 0
+#@    - max_rules is None or max_rules >= 0
 #@  post: result in ['ok', 'pruned']
 #@  assigns: [graph.nodes]
 #@end
-def enforce_rule_limit(graph: Graph, limit: int) -> str:
-    """Ensure no more than ``limit`` :class:`RuleNode` exist in ``graph``."""
+def enforce_rule_limit(
+    graph: Graph, limit: int, max_rules: int | None = None
+) -> str:
+    """Ensure the number of :class:`RuleNode` objects does not exceed ``limit``.
+
+    ``max_rules`` may specify an additional hard cap.
+    """
     assert limit >= 0
+    if max_rules is not None:
+        assert max_rules >= 0
+        limit = min(limit, max_rules)
     rules = [n for n in graph.nodes if isinstance(n, RuleNode)]
     if len(rules) > limit:
         excess = rules[limit:]

--- a/lynx.yaml
+++ b/lynx.yaml
@@ -9,3 +9,6 @@ layers:
 tools:
   verifier: true
   graph: true
+governor:
+  max_features: 5
+  max_rules: 5

--- a/tests/test_meta_governor.py
+++ b/tests/test_meta_governor.py
@@ -33,3 +33,25 @@ def test_meta_governor_relaxes_on_low_cost():
 
     assert mg.node_limit == 2
     assert mg.rule_limit == 2
+
+
+def test_meta_governor_adjusts_feature_rule_limits():
+    graph = Graph([LambdaNode("base")])
+    mg = MetaGovernor(
+        node_limit=1,
+        rule_limit=1,
+        max_features=3,
+        max_rules=3,
+        cpu_limit=1.0,
+        ram_limit=1.0,
+        graph_limit=10,
+    )
+
+    mg.evaluate(reward=0.5, cpu=2.0, ram=2.0, graph=graph)
+    assert mg.max_features == 2
+    assert mg.max_rules == 2
+
+    mg.evaluate(reward=10.0, cpu=0.1, ram=0.1, graph=graph)
+    assert mg.max_features == 3
+    assert mg.max_rules == 3
+


### PR DESCRIPTION
## Summary
- extend enforcement helpers with `max_features` and `max_rules`
- allow `MetaGovernor` to adapt feature and rule caps based on reward-cost ratio
- record defaults for the limits in `lynx.yaml`
- cover new behaviour with additional test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869483ac8488329bc98ea45ca45920f