### PR TITLE
Implement reward history and N-step updates

### DIFF
--- a/lambda_lib/memory/sequence.py
+++ b/lambda_lib/memory/sequence.py
@@ -18,9 +18,11 @@ class SequenceMemory:
 
     capacity: int = 10
     events: deque = field(init=False)
+    rewards: deque = field(init=False)
 
     def __post_init__(self) -> None:
         self.events = deque(maxlen=self.capacity)
+        self.rewards = deque(maxlen=self.capacity)
 
     #@contract:
     #@  post: len(self.events) <= self.capacity
@@ -31,12 +33,22 @@ class SequenceMemory:
         self.events.append(item)
         assert len(self.events) <= self.capacity
 
+    def push_reward(self, value: float) -> None:
+        """Store ``value`` in reward history and events."""
+        self.events.append(value)
+        self.rewards.append(value)
+        assert len(self.rewards) <= self.capacity
+
     def __len__(self) -> int:
         return len(self.events)
 
     def as_list(self) -> list:
         """Return memory contents oldest first."""
         return list(self.events)
+
+    def reward_history(self) -> list:
+        """Return stored reward signals oldest first."""
+        return list(self.rewards)
 
 
 #@contract:

--- a/lambda_lib/metrics/reward.py
+++ b/lambda_lib/metrics/reward.py
@@ -6,6 +6,7 @@
 #@end
 
 from ..core.node import LambdaNode
+from collections import deque
 
 #@contract:
 #@  post: -1.0 <= result <= 1.0
@@ -26,12 +27,18 @@ def reward(value: float, scale: float = 1.0) -> float:
 
 
 class RewardMetric(LambdaNode):
-    """Lambda node storing a normalized reward value."""
+    """Lambda node storing a normalized reward value with history."""
 
-    def __init__(self, value: float = 0.0, scale: float = 1.0):
+    def __init__(self, value: float = 0.0, scale: float = 1.0, history: int = 1):
         super().__init__("RewardMetric", data=reward(value, scale), links=[])
         self.scale = scale
+        self.history = deque([self.data], maxlen=history)
 
     def update(self, value: float) -> None:
-        """Update node data with new normalized reward value."""
+        """Update node data with new normalized reward value and history."""
         self.data = reward(value, self.scale)
+        self.history.append(self.data)
+
+    def history_list(self) -> list:
+        """Return list of stored reward values, oldest first."""
+        return list(self.history)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from lambda_lib.metrics.accuracy import accuracy
 from lambda_lib.metrics.gradient import gradient_norm
-from lambda_lib.metrics.reward import reward
+from lambda_lib.metrics.reward import reward, RewardMetric
 
 
 def test_accuracy_basic():
@@ -24,3 +24,12 @@ def test_reward_scaling():
     assert reward(0.5, scale=1.0) == 0.5
     assert reward(2.0, scale=1.0) == 1.0
     assert reward(-3.0, scale=1.0) == -1.0
+
+
+def test_reward_metric_history():
+    metric = RewardMetric(history=3)
+    metric.update(0.5)
+    metric.update(-0.5)
+    metric.update(0.8)
+    metric.update(0.1)
+    assert metric.history_list() == [reward(-0.5), reward(0.8), reward(0.1)]

--- a/tests/test_sequence_memory.py
+++ b/tests/test_sequence_memory.py
@@ -27,16 +27,17 @@ def test_n_step_reward_influences_learning():
         preds_nomem.append(p_nomem)
         p_mem = int(weight_mem > 0.5)
         preds_mem.append(p_mem)
-        if t >= 2:
-            r = 1.0 if preds_mem[t-2] == labels[t-2] else -1.0
-            memory.push(r)
+        if t >= memory.capacity:
+            r = 1.0 if preds_mem[t - memory.capacity] == labels[t - memory.capacity] else -1.0
+            memory.push_reward(r)
             weight_mem = convolve_context(weight_mem, memory, weight=0.5)
 
-    for t in range(len(labels) - 2, len(labels)):
+    for t in range(len(labels) - memory.capacity, len(labels)):
         r = 1.0 if preds_mem[t] == labels[t] else -1.0
-        memory.push(r)
+        memory.push_reward(r)
         weight_mem = convolve_context(weight_mem, memory, weight=0.5)
 
     assert weight_nomem == 0.0
     assert weight_mem != weight_nomem
+    assert len(memory.reward_history()) <= memory.capacity
 


### PR DESCRIPTION
## Summary
- extend `RewardMetric` with reward history tracking
- allow `SequenceMemory` to store reward signals
- update tests for delayed reward mechanics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869497dc84c832996a654f19b727dae