### PR TITLE
Add FeatureDiscoverer quick start and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ python -m lambda_lib.examples.simple_eval
 ```
 *Until implementation lands, explore the contracts to understand the planned behaviour.*
 
+### Quick-start: FeatureDiscoverer
+```python
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.graph import Graph
+from lambda_lib.ops.feature_discoverer import discover
+from lambda_lib.ops.spawn_feature import spawn_feature
+
+g = Graph([])
+g.add(LambdaNode("Event", data={"latency_ms": 100, "label": 0}))
+g.add(LambdaNode("Event", data={"latency_ms": 400, "label": 1}))
+
+for expr in discover([n for n in g.nodes if n.label == "Event"]):
+    g.add(spawn_feature(LambdaNode("FeatureDiscoverer", data={"expr": expr})))
+
+print([n.label for n in g.nodes if n.label.startswith("Feature:")])
+```
+
 ---
 
 ## 9 Roadmap

--- a/docs/guide/drift_concepts.md
+++ b/docs/guide/drift_concepts.md
@@ -1,0 +1,28 @@
+# Drift concepts
+
+This short example shows how concept nodes emerge from new features.
+
+```python
+from lambda_lib.core.node import LambdaNode
+from lambda_lib.graph import Graph
+from lambda_lib.ops.spawn_feature import spawn_feature
+
+# start with an empty graph
+graph = Graph([])
+
+# create a new feature description
+fd = LambdaNode("FeatureDiscoverer", data={"expr": "latency_ms"})
+feature = spawn_feature(fd)
+
+# once the feature proves useful (e.g. high correlation)
+feature.data = {"latency_ms": 0.92}
+
+# adding the feature spawns a rule and a concept automatically
+graph.add(feature)
+
+for node in graph.nodes:
+    print(node.label, node.data)
+```
+
+Running it prints a `Concept:latency_ms` node alongside a new rule
+`Rule:latency_ms` completing the `spawn_feature → spawn_op → concept` chain.

--- a/lambda_lib/examples/feature_to_concept.py
+++ b/lambda_lib/examples/feature_to_concept.py
@@ -1,0 +1,28 @@
+#@module:
+#@  version: "0.3"
+#@  layer: examples
+#@  exposes: [main]
+#@  doc: Demonstrates spawn_feature -> spawn_op -> concept chain.
+#@end
+from __future__ import annotations
+
+from ..core.node import LambdaNode
+from ..graph import Graph
+from ..ops.spawn_feature import spawn_feature
+
+
+def main() -> None:
+    graph = Graph([])
+
+    fd = LambdaNode("FeatureDiscoverer", data={"expr": "latency_ms"})
+    feature = spawn_feature(fd)
+    feature.data = {"latency_ms": 0.95}
+
+    graph.add(feature)
+
+    for node in graph.nodes:
+        print(node.label, node.data)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()

--- a/lambda_lib/examples/simple_eval.py
+++ b/lambda_lib/examples/simple_eval.py
@@ -4,4 +4,58 @@
 #@  exposes: []
 #@  doc: Example demonstrating simple eval flow.
 #@end
-# No implementation – contracts only.
+from __future__ import annotations
+
+from ..core.engine import LambdaEngine
+from ..core.node import LambdaNode
+from ..core.operation import LambdaOperation
+from ..graph import Graph
+
+
+def build_graph(samples: list[dict]) -> tuple[LambdaEngine, Graph]:
+    """Return engine and graph for a simple evaluation loop."""
+    idx = 0
+    current = None
+
+    def sensor(node: LambdaNode) -> LambdaNode:
+        nonlocal idx, current
+        current = samples[idx] if idx < len(samples) else None
+        idx += 1
+        return LambdaNode("Sensor", data=current, links=node.links)
+
+    def feature_maker(node: LambdaNode) -> LambdaNode:
+        return LambdaNode("FeatureMaker", data=current, links=node.links)
+
+    def model(node: LambdaNode) -> LambdaNode:
+        pred = None
+        if current:
+            pred = int(current.get("latency_ms", 0) >= 500)
+        return LambdaNode("Model", data=pred, links=node.links)
+
+    engine = LambdaEngine()
+    engine.register(LambdaOperation("Sensor", sensor))
+    engine.register(LambdaOperation("FeatureMaker", feature_maker))
+    engine.register(LambdaOperation("Model", model))
+
+    graph = Graph([
+        LambdaNode("Sensor"),
+        LambdaNode("FeatureMaker", raw=True),
+        LambdaNode("Model"),
+    ])
+
+    return engine, graph
+
+
+def main() -> None:
+    samples = [
+        {"latency_ms": 100, "label": 0},
+        {"latency_ms": 700, "label": 1},
+    ]
+    engine, graph = build_graph(samples)
+    for _ in samples:
+        engine.execute(graph)
+        print([f"{n.label}:{n.data}" for n in graph.nodes])
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()


### PR DESCRIPTION
## Summary
- add a quick-start code snippet using FeatureDiscoverer in README
- document concept drift example under `docs/guide/`
- implement a new demo `feature_to_concept.py`
- flesh out `simple_eval.py` into a runnable example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694a6b42a08329a96809f6c2f7aef4