### PR TITLE
Add dynamic checks for feature, rules and concept behaviour

### DIFF
--- a/tests/test_concept_inventor.py
+++ b/tests/test_concept_inventor.py
@@ -30,3 +30,18 @@ def test_feature_to_concept_to_rule_chain():
     rules = [n for n in graph.nodes if isinstance(n, RuleNode)]
     assert any(c.label == "Concept:foo" for c in concepts)
     assert len([r for r in rules if r.label == "Rule:foo"]) >= 2
+
+
+def test_concept_node_improves_metric():
+    _best_corr.clear()
+    graph = Graph([])
+
+    graph.add(LambdaNode("Metric", data={"foo": 0.5}))
+    baseline = _best_corr.get("foo", 0.0)
+
+    graph.add(LambdaNode("Metric", data={"foo": 0.95}))
+    concepts = [n for n in graph.nodes if isinstance(n, ConceptNode)]
+
+    assert len(concepts) >= 1
+    assert _best_corr.get("foo", 0.0) > baseline
+

--- a/tests/test_feature_spawn.py
+++ b/tests/test_feature_spawn.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from lambda_lib.core.node import LambdaNode
 from lambda_lib.graph import Graph
 from lambda_lib.ops.spawn_feature import spawn_feature
-from lambda_lib.ops.feature_discoverer import FeatureNode
+from lambda_lib.ops.feature_discoverer import FeatureNode, _event_memory
 from lambda_lib.governance.governor import enforce_feature_limit
 
 
@@ -23,3 +23,35 @@ def test_feature_spawn_and_governor_pruning():
     assert len([n for n in graph.nodes if isinstance(n, FeatureNode)]) == 5
     enforce_feature_limit(graph, limit=3)
     assert len([n for n in graph.nodes if isinstance(n, FeatureNode)]) == 3
+
+
+def test_feature_growth_with_changing_correlation():
+    _event_memory.events.clear()
+    graph = Graph([])
+
+    correlated = [
+        {"x": 0, "label": 0},
+        {"x": 1, "label": 1},
+        {"x": 0, "label": 0},
+    ]
+    for event in correlated:
+        graph.add(LambdaNode("Event", data=event))
+
+    initial = len([n for n in graph.nodes if isinstance(n, FeatureNode)])
+    assert initial > 0
+
+    uncorrelated = [
+        {"x": 1, "label": 0},
+        {"x": 0, "label": 1},
+        {"x": 1, "label": 0},
+    ]
+    for event in uncorrelated:
+        graph.add(LambdaNode("Event", data=event))
+
+    grown = len([n for n in graph.nodes if isinstance(n, FeatureNode)])
+    assert grown > initial
+
+    enforce_feature_limit(graph, limit=1)
+    final = len([n for n in graph.nodes if isinstance(n, FeatureNode)])
+    assert final == 1
+

--- a/tests/test_runtime_dynamic_rules.py
+++ b/tests/test_runtime_dynamic_rules.py
@@ -15,18 +15,21 @@ def test_dynamic_rule_activation():
     engine = LambdaEngine()
 
     def base(node: LambdaNode) -> LambdaNode:
-        return LambdaNode("A", data=node.data, links=node.links)
+        return LambdaNode("A", data=0, links=node.links)
 
     engine.register(LambdaOperation("A", base))
 
     graph = Graph([LambdaNode("A")])
 
     engine.execute(graph)
+    before = int(graph.nodes[0].data)
 
-    rule = RuleNode("B", parse_pattern("A -> B"))
+    rule = RuleNode("B", parse_pattern("A -> 1"))
     graph.add(rule)
 
     engine.execute(graph)
+    after = int(graph.nodes[0].data)
 
     assert any(evt[0] == "rule_spawned" for evt in engine.events)
-    assert graph.nodes[0].data == "B"
+    assert after > before
+


### PR DESCRIPTION
## Summary
- test feature growth under changing correlation and pruning
- verify dynamic rule application improves metric
- ensure concept nodes improve tracked metric

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694bb9bcb883299d2a8e530cb2c264