### PR TITLE
Handle URLError in http stream

### DIFF
--- a/lambda_lib/sensors/http_stream.py
+++ b/lambda_lib/sensors/http_stream.py
@@ -28,7 +28,7 @@ def http_stream(url: str) -> HTTPStreamResult:
     try:
         with urlopen(url) as resp:
             data = resp.read().decode("utf-8")
-    except Exception:
+    except URLError:
         data = ""
     result = HTTPStreamResult(new_data=data)
     assert result.new_data is not None

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from lambda_lib.sensors.file_tail import tail_file
 from lambda_lib.sensors.http_stream import http_stream
+from urllib.error import URLError
 
 
 def test_tail_file(tmp_path):
@@ -35,7 +36,7 @@ def test_http_stream(monkeypatch):
     assert res.new_data == "data"
 
     def raising(url):
-        raise Exception("fail")
+        raise URLError("fail")
 
     monkeypatch.setattr("lambda_lib.sensors.http_stream.urlopen", raising)
     res2 = http_stream("http://example.com")


### PR DESCRIPTION
## Summary
- catch `URLError` instead of generic `Exception` in `http_stream`
- test `http_stream` returns an empty string when `URLError` is raised

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694d230c948329abe1c85270cea5fa