### PR TITLE
Fix CLI example path resolution

### DIFF
--- a/lambda_lib/cli.py
+++ b/lambda_lib/cli.py
@@ -47,6 +47,11 @@ def main(argv: Sequence[str]) -> int:
 
     if command == "run" and len(argv) >= 3:
         seed_file = argv[2]
+        path = Path(seed_file)
+        if not path.exists():
+            alt = Path(__file__).resolve().parent / seed_file
+            if alt.exists():
+                seed_file = str(alt)
         steps = 1
         if "--steps" in argv:
             idx = argv.index("--steps")


### PR DESCRIPTION
## Summary
- resolve CLI seed file paths relative to package when missing

## Testing
- `pytest -q`
- `python -m lambda_lib.cli run examples/classifier/seed.yaml --steps 2`

------
https://chatgpt.com/codex/tasks/task_e_686950e21ac88329bd3122c00ff25fa6